### PR TITLE
deallocate RCTAVPlayer when [RCTAVPlayerManager invalidate] is sent

### DIFF
--- a/RCTAVPlayer.h
+++ b/RCTAVPlayer.h
@@ -17,4 +17,5 @@
 -(void)applyModifiers;
 -(void)setRepeat:(BOOL)repeat;
 -(AVPlayer*)getAVPlayer;
+-(void)invalidate;
 @end

--- a/RCTAVPlayer.m
+++ b/RCTAVPlayer.m
@@ -369,6 +369,11 @@ static NSString *const playbackLikelyToKeepUpKeyPath = @"playbackLikelyToKeepUp"
 
 #pragma mark - Lifecycle
 
+-(void)invalidate
+{
+    [self stopProgressTimer];
+}
+
 -(void)dealloc
 {
   [_progressUpdateTimer invalidate];

--- a/RCTAVPlayerManager.h
+++ b/RCTAVPlayerManager.h
@@ -1,7 +1,8 @@
 #import "RCTBridgeModule.h"
 #import "RCTAVPlayer.h"
+#import "RCTInvalidating.h"
 
-@interface RCTAVPlayerManager : NSObject <RCTBridgeModule>
+@interface RCTAVPlayerManager : NSObject <RCTBridgeModule, RCTInvalidating>
 
 +(RCTAVPlayer*)getPlayer:(NSString*)playerUuid;
 

--- a/RCTAVPlayerManager.m
+++ b/RCTAVPlayerManager.m
@@ -123,6 +123,7 @@ RCT_EXPORT_METHOD(removePlayer:(NSString*)playerUuid withCallback:(RCTResponseSe
         callback(@[@"ERROR: Player with uuid not found!"]);
         return;
     }
+    [_players[playerUuid] invalidate];
     [_players removeObjectForKey:playerUuid];
     callback(@[[NSNull null], playerUuid]);
 }
@@ -135,6 +136,15 @@ RCT_EXPORT_METHOD(removePlayer:(NSString*)playerUuid withCallback:(RCTResponseSe
         return nil;
     }
     return _players[playerUuid];
+}
+
+-(void)invalidate
+{
+    for (NSString* playerUuid in _players)
+    {
+        [_players[playerUuid] invalidate];
+    }
+    _players = nil;
 }
 
 @end


### PR DESCRIPTION
Release objects when invalidate is sent to the module. (Stop timer that references the RCTAVPlayer's sendProgressUpdate method, stopping arc from releasing the object)
